### PR TITLE
Modify omnetpp-gui dockerfile to use version 6.0.1

### DIFF
--- a/omnetpp-gui/Dockerfile
+++ b/omnetpp-gui/Dockerfile
@@ -1,26 +1,28 @@
-#!/usr/bin/env docker build --build-arg VERSION=5.6.2 -t omnetpp/omnetpp-gui:u18.04-5.6.2 .
-#
+FROM ghcr.io/omnetpp/omnetpp-base:u22.04-1 as base
 
-FROM omnetpp/omnetpp-base:u18.04 as base
 LABEL maintainer="Rudolf Hornig <rudi@omnetpp.org>"
-RUN apt-get update -y && apt-get install -y --no-install-recommends qt5-default libqt5opengl5-dev \
-            libgtk-3-0 libwebkitgtk-3.0-0 default-jre gcc g++ gdb
+
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends qtbase5-dev qtchooser\
+                          qt5-qmake qtbase5-dev-tools libqt5opengl5-dev libwebkit2gtk-4.0-37
 
 # first stage - build OMNeT++ with GUI
 FROM base as builder
 
 ARG VERSION
 WORKDIR /root
-RUN wget https://github.com/omnetpp/omnetpp/releases/download/omnetpp-$VERSION/omnetpp-$VERSION-src-linux.tgz \
-         --referer=https://omnetpp.org/ -O omnetpp-src-linux.tgz --progress=dot:giga && \
-         tar xf omnetpp-src-linux.tgz && rm omnetpp-src-linux.tgz
+RUN wget https://github.com/omnetpp/omnetpp/releases/download/omnetpp-$VERSION/omnetpp-$VERSION-linux-x86_64.tgz \
+         --referer=https://omnetpp.org/ -O omnetpp-core.tgz --progress=dot:giga && \
+         tar xf omnetpp-core.tgz && rm omnetpp-core.tgz
+
 RUN mv omnetpp-$VERSION omnetpp
 WORKDIR /root/omnetpp
 ENV PATH /root/omnetpp/bin:$PATH
 # remove unused files and build
-RUN ./configure WITH_OSG=no WITH_OSGEARTH=no && \
-    make -j $(nproc) MODE=debug base && make -j $(nproc) MODE=release base && \
-    rm -r doc out test samples config.log config.status
+RUN . ./setenv && \
+    ./configure WITH_LIBXML=yes WITH_OSG=no WITH_OSGEARTH=no && \
+    make -j $(nproc) MODE=release base && \
+    rm -r doc out test samples misc config.log config.status
 
 # second stage - copy only the final binaries (to get rid of the 'out' folder and reduce the image size)
 FROM base

--- a/omnetpp-gui/build
+++ b/omnetpp-gui/build
@@ -1,3 +1,3 @@
 #!/bin/sh
-VERSION=5.6.2
-docker build --build-arg VERSION=$VERSION -t omnetpp/omnetpp-gui:u18.04-$VERSION .
+VERSION=6.0.1
+docker build --build-arg VERSION=$VERSION -t ghcr.io/omnetpp/omnetpp-gui:u22.05-$VERSION .

--- a/omnetpp-gui/opp_gui_docker_shell
+++ b/omnetpp-gui/opp_gui_docker_shell
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm -it -v "$(pwd):/root/models" -u "$(id -u):$(id -g)" -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY omnetpp/omnetpp-gui:u18.04-5.6.2
+docker run --rm -it -v "$(pwd):/root/models" -u "$(id -u):$(id -g)" -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY ghcr.io/omnetpp/omnetpp-gui:u22.05-6.0.1

--- a/omnetpp-gui/opp_gui_x11docker_shell
+++ b/omnetpp-gui/opp_gui_x11docker_shell
@@ -1,2 +1,2 @@
 #!/bin/sh
-x11docker -i --sudouser -- --rm -v "$(pwd):/root/models" -u "$(id -u):$(id -g)" -- omnetpp/omnetpp-gui:u18.04-5.6.2
+x11docker -i --sudouser -- --rm -v "$(pwd):/root/models" -u "$(id -u):$(id -g)" -- ghcr.io/omnetpp/omnetpp-gui:u22.05-6.0.1


### PR DESCRIPTION
I needed Omnet++ 6.0.1 for college so I've tried my best to upgrade the omnetpp-gui dockerfile and related scripts to version 6.0.1.

I took inspiration from the existing images already upgraded to 6.0.1.

I've tested the Docker image created from the Dockerfile, and everything seems to be working fine, including the GUI.

Please give it a look and let me know if there's anything that need to be changed.
Feedback is more than welcome!